### PR TITLE
fix: add packagingOptions to allow building on AGP 7.1.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,4 +59,8 @@ android {
     defaultConfig {
         minSdkVersion 19
     }
+
+    packagingOptions {
+        pickFirst '**/libpdfium.so'
+    }
 }


### PR DESCRIPTION
Doing this (mentioned [here](https://github.com/espresso3389/pdfrx/issues/8#issuecomment-1898225027)) allows us to build against AGP 7.1.2. Downgrading from 7.4.2 to 7.1.2 is necessary to allow the use of `native_dio_adapter` (which uses `jni` which builds using an older Kotlin version that is incompatible with AGP 7.4.2).

Once `jni` bumps their kotlin version to 1.6.20+ we can bump back to AGP 7.4.2 and delete this fork.